### PR TITLE
Multi-threaded use on a cluster

### DIFF
--- a/Blast/Blastn.py
+++ b/Blast/Blastn.py
@@ -14,9 +14,10 @@ def align  (query_list,
             subject_db = None,
             subject_fasta = None,
             aligner = "blastn",
-            align_opt="",
+            align_opt = "",
+            num_threads = 1,
             db_maker = "makeblastdb",
-            db_opt="",
+            db_opt = "",
             db_outdir = "./blast_db/",
             db_outname = "out"):
 
@@ -61,7 +62,7 @@ def align  (query_list,
         db = NewDB(ref_path=subject_fasta, db_path=db_path, makeblastdb_opt=db_opt, makeblastdb=db_maker)
 
     # Initialise a Blastn object
-    blast = Aligner(db, align_opt, aligner)
+    blast = Aligner(db, align_opt, aligner, num_threads)
     #~print (repr(blast))
 
     # Generate a list of hit containing hits of all sequence in query list in subject

--- a/Blast/BlastnWrapper.py
+++ b/Blast/BlastnWrapper.py
@@ -31,7 +31,7 @@ class Aligner(object):
     def __str__(self):
         return "<Instance of {} from {} >\n".format(self.__class__.__name__, self.__module__)
 
-    def __init__ (self, Blastdb, blastn_opt="", blastn="blastn"):
+    def __init__ (self, Blastdb, blastn_opt="", blastn="blastn", num_threads=1):
         """
         Initialize the object and index the reference genome if necessary
         @param Blastdb Blast database object NewDB or ExistingDB
@@ -42,10 +42,14 @@ class Aligner(object):
         # Creating object variables
         self.blastn = blastn
         self.Blastdb = Blastdb
+        self.num_threads = num_threads
 
         # init an option dict and attribute defaut options
+        # if num_threads == 0 use all cores on the node
+        if self.num_threads == 0:
+            self.num_threads = cpu_count()
         self.blastn_opt = "{} -num_threads {} -task {} -outfmt {} -dust {} -db {}".format(
-            blastn_opt, cpu_count(), "blastn", 6, "no", self.Blastdb.db_path)
+            blastn_opt, self.num_threads, "blastn", 6, "no", self.Blastdb.db_path)
 
     #~~~~~~~PUBLIC METHODS~~~~~~~#
 

--- a/Bwa/Mem.py
+++ b/Bwa/Mem.py
@@ -17,6 +17,7 @@ def align  (R1,
             ref = '',
             aligner = "bwa mem",
             align_opt="",
+            bwa_threads = 1,
             align_outdir= "./bwa_align/",
             align_outname= "out.sam",
             indexer = "bwa index",
@@ -66,7 +67,7 @@ def align  (R1,
         idx = NewIndex(ref, index_path, index_opt, indexer)
 
     # Create a Aligner object
-    mem = Aligner(idx, align_opt, aligner)
+    mem = Aligner(idx, align_opt, aligner, bwa_threads)
     #~print (repr(mem))
     mkdir(align_outdir)
 

--- a/Bwa/Mem.py
+++ b/Bwa/Mem.py
@@ -17,7 +17,7 @@ def align  (R1,
             ref = '',
             aligner = "bwa mem",
             align_opt="",
-            bwa_threads = 1,
+            align_threads = 1,
             align_outdir= "./bwa_align/",
             align_outname= "out.sam",
             indexer = "bwa index",
@@ -67,7 +67,7 @@ def align  (R1,
         idx = NewIndex(ref, index_path, index_opt, indexer)
 
     # Create a Aligner object
-    mem = Aligner(idx, align_opt, aligner, bwa_threads)
+    mem = Aligner(idx, align_opt, aligner, align_threads)
     #~print (repr(mem))
     mkdir(align_outdir)
 

--- a/Bwa/MemWrapper.py
+++ b/Bwa/MemWrapper.py
@@ -29,7 +29,7 @@ class Aligner(object):
     def __str__(self):
         return "<Instance of {} from {} >\n".format(self.__class__.__name__, self.__module__)
 
-    def __init__ (self, Index, align_opt="", aligner = "bwa mem"):
+    def __init__ (self, Index, align_opt="", aligner = "bwa mem", bwa_threads = 1):
         """
         Initialize the object and index the reference genome if necessary
         @param Index Bwa index object NewIndex or ExistingIndex
@@ -39,8 +39,12 @@ class Aligner(object):
         # Creating object variables
         self.aligner = aligner
         self.Index = Index
+        self.bwa_threads = bwa_threads
+        # if bwa_threads == 0 use all cores on the node
+        if self.bwa_threads == 0:
+            self.bwa_threads = cpu_count()
         # By default the option t is setted to the max number of available threads
-        self.align_opt = "{} -t {}".format(align_opt, cpu_count())
+        self.align_opt = "{} -t {}".format(align_opt, bwa_threads)
 
     #~~~~~~~PUBLIC METHODS~~~~~~~#
 


### PR DESCRIPTION
A small patch to allow more deterministic use within a restricted computing environment such as a generic  cluster. Since programs cannot assume that all processor cores on a computing node are available allow the user to specify the number of threads. Only use all cores if thread number is set to zero.

Patch tested with a full project run.